### PR TITLE
extend for yml scanning

### DIFF
--- a/ephemerol/Scanner.py
+++ b/ephemerol/Scanner.py
@@ -179,7 +179,21 @@ def get_scan_func(fname):
         return webconfig_file_scan
     elif fname.endswith('.cs'):
         return cs_file_scan
+    elif fname.endswith('.yml'):
+        return yml_file_scan
 
+
+def yml_file_scan(file_lines, filename):
+    ymlrules = []
+    global scan_results
+    for rule in rulebase:
+        if (rule.file_type == "config") and (rule.file_name == "*.yml") and (rule.text_pattern != "NONE"):
+            ymlrules.append(rule)
+
+    for line in file_lines:
+        for rule in ymlrules:
+            if rule.text_pattern in line:
+                scan_results.append(ScanResult(scan_item=rule, flagged_file_id=filename))
 
 def xml_file_scan(file_lines, filename):
     xmlrules = []

--- a/ephemerol/static/default-rulebase.yml
+++ b/ephemerol/static/default-rulebase.yml
@@ -194,6 +194,16 @@
   text_patterns:
     - "port=": { description: "Port Hard Code", replatform_advice: "Switch to configuration injected via environment" }
     - "file://": { description: "Local Filesystem Reference", replatform_advice: "Read only, immutable files are ok, but writing to the local filesystem will not persist.  Investigate local filesystem access further, and refactor code that stores local data to use an external service, if necessary." }
+    - "http://": { description: "HTTP URL hardcoded", replatform_advice: "Externalize URLs" }
+    - "https://": { description: "HTTPS URL hardcoded", replatform_advice: "Externalize URLs" }
+- category: "12 Factor"
+  app_type: java
+  file_type: config
+  refactor_rating: 1
+  file_pattern: "*.yml"
+  text_patterns:
+    - "http://": { description: "HTTP URL hardcoded", replatform_advice: "Externalize URLs" }
+    - "https://": { description: "HTTPS URL hardcoded", replatform_advice: "Externalize URLs" }
 - category: ".NET Framework"
   app_type: dotnet
   file_type: config

--- a/ephemerol/static/default-rulebase.yml
+++ b/ephemerol/static/default-rulebase.yml
@@ -204,6 +204,8 @@
   text_patterns:
     - "http://": { description: "HTTP URL hardcoded", replatform_advice: "Externalize URLs" }
     - "https://": { description: "HTTPS URL hardcoded", replatform_advice: "Externalize URLs" }
+    - "password:": { description: "Password parameter", replatform_advice: "Review to ensure password is not in cleartext" }
+    - "apiKey:": { description: "API Key parameter", replatform_advice: "Review to ensure API Key is not in cleartext" }
 - category: ".NET Framework"
   app_type: dotnet
   file_type: config


### PR DESCRIPTION
Added check for *.yml to Scanner.py and additional 12-factor category for yml scanning of URL's, passwords, and apiKeys.